### PR TITLE
9999999999_マイグレーションをリネーム, 初期データ投入down時のデータ削除

### DIFF
--- a/Config/Migration/1472409223_records.php
+++ b/Config/Migration/1472409223_records.php
@@ -104,16 +104,23 @@ class Records extends NetCommonsMigration {
  * @return bool Should process continue
  */
 	public function after($direction) {
-		if ($direction === 'down') {
-			return true;
-		}
-
 		foreach ($this->records as $model => $records) {
-			if (!$this->updateRecords($model, $records)) {
-				return false;
+			if ($direction === 'up') {
+				if (!$this->updateRecords($model, $records)) {
+					return false;
+				}
+			} elseif ($direction === 'down') {
+				if ($model == 'LanguagesPage') {
+					if (!$this->deleteRecords($model, $records, 'page_id')) {
+						return false;
+					}
+				} else {
+					if (!$this->deleteRecords($model, $records)) {
+						return false;
+					}
+				}
 			}
 		}
-
 		return true;
 	}
 

--- a/Test/Fixture/Box4pagesFixture.php
+++ b/Test/Fixture/Box4pagesFixture.php
@@ -38,7 +38,7 @@ class Box4pagesFixture extends BoxFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '9999999999_box_records.php';
+		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '1472409223_box_records.php';
 		$this->records = (new BoxRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4

--- a/Test/Fixture/BoxesPage4pagesFixture.php
+++ b/Test/Fixture/BoxesPage4pagesFixture.php
@@ -38,7 +38,7 @@ class BoxesPage4pagesFixture extends BoxesPageFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '9999999999_box_records.php';
+		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '1472409223_box_records.php';
 		$this->records = (new BoxRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4

--- a/Test/Fixture/BoxesPage4routesFixture.php
+++ b/Test/Fixture/BoxesPage4routesFixture.php
@@ -38,7 +38,7 @@ class BoxesPage4routesFixture extends BoxesPageFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '9999999999_box_records.php';
+		require_once App::pluginPath('Boxes') . 'Config' . DS . 'Migration' . DS . '1472409223_box_records.php';
 		$this->records = (new BoxRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4

--- a/Test/Fixture/Container4pagesFixture.php
+++ b/Test/Fixture/Container4pagesFixture.php
@@ -38,7 +38,7 @@ class Container4pagesFixture extends ContainerFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '9999999999_container_records.php';
+		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '1472409223_container_records.php';
 		$this->records = (new ContainerRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4

--- a/Test/Fixture/ContainersPage4pagesFixture.php
+++ b/Test/Fixture/ContainersPage4pagesFixture.php
@@ -38,7 +38,7 @@ class ContainersPage4pagesFixture extends ContainersPageFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '9999999999_container_records.php';
+		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '1472409223_container_records.php';
 		$this->records = (new ContainerRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4

--- a/Test/Fixture/ContainersPage4routesFixture.php
+++ b/Test/Fixture/ContainersPage4routesFixture.php
@@ -38,7 +38,7 @@ class ContainersPage4routesFixture extends ContainersPageFixture {
  * @return void
  */
 	public function init() {
-		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '9999999999_container_records.php';
+		require_once App::pluginPath('Containers') . 'Config' . DS . 'Migration' . DS . '1472409223_container_records.php';
 		$this->records = (new ContainerRecords())->records[$this->name];
 
 		//パブリックスペースのホーム/test4


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/589

9999999999_box_records, 9999999999_container_recordsのリネームの下記プルリクエストも行ったため、トラビスこけるかもです。

https://github.com/NetCommons3/Boxes/pull/22
https://github.com/NetCommons3/Containers/pull/21
