### PR TITLE
refs #1352  サブルームを作成すると、Permalinkが親ルームのPermalinkが含まれないSpace直下のものとして作成される

### DIFF
--- a/Model/Behavior/SavePageBehavior.php
+++ b/Model/Behavior/SavePageBehavior.php
@@ -53,7 +53,11 @@ class SavePageBehavior extends ModelBehavior {
 		}
 		$model->data['Page']['slug'] = $slug;
 
-		$permalink = $model->getTopPagePermalink($model->data['Page']) . '/' . $slug;
+		$permalink = Hash::get(
+			$model->data,
+			'Page.permalink',
+			$model->getTopPagePermalink($model->data['Page']) . '/' . $slug
+		);
 		if (substr($permalink, 0, 1) === '/') {
 			$permalink = substr($permalink, 1);
 		}


### PR DESCRIPTION
サブルーム作成のときはpermalinkがちゃんと階層化されるように変更
これまでのサブルームが階層化されていないわけであるが、すでに運用に入っていることを考えると、むやみに過去に作成されたサブルームのパーマリンクは変更しないほうが妥当と考えた。
そのため既に作成されたサブルームのパーマリンクを変更するようなMigrationは作成してない。